### PR TITLE
Updated Iris-Smart-Plug.src to include importUrl parameter to the metadata definition

### DIFF
--- a/Drivers/Iris-Smart-Plug.src
+++ b/Drivers/Iris-Smart-Plug.src
@@ -16,7 +16,7 @@
 metadata 
 {
 	// Automatically generated. Make future change here.
-	definition(name: "Iris Smart Plug", namespace: "shackrat", author: "Steve White")
+	definition(name: "Iris Smart Plug", namespace: "shackrat", author: "Steve White", importUrl: "https://raw.githubusercontent.com/shackrat/Hubitat/master/Drivers/Iris-Smart-Plug.src")
 	{
 		capability "Actuator"
 		capability "Switch"


### PR DESCRIPTION
I added the importUrl parameter to the metadata definition so that the github URL will be auto-filled when you click the "Import" button:

Changed from
	definition (name: "Iris Smart Plug", namespace: "shackrat", author: "Steve White")
to
	definition (name: "Iris Smart Plug", namespace: "shackrat", author: "Steve White", importUrl: "https://raw.githubusercontent.com/shackrat/Hubitat/master/Drivers/Iris-Smart-Plug.src")