### PR TITLE
Updated Iris-ZWave-Repeater.src to include importUrl parameter to the metadata definition

### DIFF
--- a/Drivers/Iris-ZWave-Repeater.src
+++ b/Drivers/Iris-ZWave-Repeater.src
@@ -18,7 +18,7 @@ def getDriverVersion() {[platform: "Hubitat", major: 2, minor: 0, build: 0]}
 
 metadata
 {
-	definition (name: "Iris Z-Wave Repeater", namespace: "shackrat", author: "Steve White")
+	definition (name: "Iris Z-Wave Repeater", namespace: "shackrat", author: "Steve White", importUrl: "https://raw.githubusercontent.com/shackrat/Hubitat/master/Drivers/Iris-ZWave-Repeater.src")
 	{
 		capability "Polling"
 		capability "Refresh"


### PR DESCRIPTION
I added the importUrl parameter to the metadata definition so that the github URL will be auto-filled when you click the "Import" button:

Change from
   definition (name: "Iris Z-Wave Repeater", namespace: "shackrat", author: "Steve White")
to
   definition (name: "Iris Z-Wave Repeater", namespace: "shackrat", author: "Steve White", importUrl: "https://raw.githubusercontent.com/shackrat/Hubitat/master/Drivers/Iris-ZWave-Repeater.src")